### PR TITLE
Feat | getSpotifyTrackMetadata  prioritize YouTube

### DIFF
--- a/lib/spotify/getSpotifyTrackMetadata.tsx
+++ b/lib/spotify/getSpotifyTrackMetadata.tsx
@@ -2,12 +2,19 @@ import { TrackMetadata } from '@/types/Track';
 import getSpotifyTrackId from './getSpotifyTrackId';
 import { SupabasePost } from '@/types/SupabasePost';
 import getSoundcloudTrackMetadata from '../soundcloud/getSoundcloudTrackMetadata';
+import getYoutubeTrackMetadata from "@/lib/youtube/getYoutubeTrackMetadata";
 
 const getSpotifyTrackMetadata = async (url: string, cast: SupabasePost) => {
+  const youtubeLink = cast.alternativeEmbeds.find((link) => link.includes('youtube.com'));
   const soundcloudLink = cast.alternativeEmbeds.find((link) => link.includes('soundcloud.com'));
+  const spotifyLink = cast.alternativeEmbeds.find((link) => link.includes('spotify.com'));
 
-  if (soundcloudLink) {
+  if (youtubeLink) {
+    return await getYoutubeTrackMetadata(youtubeLink, cast);
+  } else if(soundcloudLink) {
     return await getSoundcloudTrackMetadata(soundcloudLink, cast);
+  } else if(spotifyLink) {
+    return await getSpotifyTrackMetadata(spotifyLink, cast);
   }
 
   const oEmbedUrl = `https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`;

--- a/lib/spotify/getSpotifyTrackMetadata.tsx
+++ b/lib/spotify/getSpotifyTrackMetadata.tsx
@@ -4,7 +4,7 @@ import { SupabasePost } from '@/types/SupabasePost';
 import getSoundcloudTrackMetadata from '../soundcloud/getSoundcloudTrackMetadata';
 import getYoutubeTrackMetadata from "@/lib/youtube/getYoutubeTrackMetadata";
 
-const getSpotifyTrackMetadata = async (url: string, cast: SupabasePost) => {
+const getSpotifyTrackMetadata = async (url: string, cast: SupabasePost): Promise<TrackMetadata> => {
   const youtubeLink = cast.alternativeEmbeds.find((link) => link.includes('youtube.com'));
   const soundcloudLink = cast.alternativeEmbeds.find((link) => link.includes('soundcloud.com'));
   const spotifyLink = cast.alternativeEmbeds.find((link) => link.includes('spotify.com'));

--- a/lib/spotify/getSpotifyTrackMetadata.tsx
+++ b/lib/spotify/getSpotifyTrackMetadata.tsx
@@ -13,9 +13,10 @@ const getSpotifyTrackMetadata = async (url: string, cast: SupabasePost): Promise
     return await getYoutubeTrackMetadata(youtubeLink, cast);
   } else if(soundcloudLink) {
     return await getSoundcloudTrackMetadata(soundcloudLink, cast);
-  } else if(spotifyLink) {
-    return await getSpotifyTrackMetadata(spotifyLink, cast);
   }
+
+  return await getSpotifyTrackMetadata(spotifyLink!, cast);
+
 
   const oEmbedUrl = `https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`;
   const response = await fetch(oEmbedUrl);

--- a/lib/spotify/getSpotifyTrackMetadata.tsx
+++ b/lib/spotify/getSpotifyTrackMetadata.tsx
@@ -7,16 +7,14 @@ import getYoutubeTrackMetadata from "@/lib/youtube/getYoutubeTrackMetadata";
 const getSpotifyTrackMetadata = async (url: string, cast: SupabasePost): Promise<TrackMetadata> => {
   const youtubeLink = cast.alternativeEmbeds.find((link) => link.includes('youtube.com'));
   const soundcloudLink = cast.alternativeEmbeds.find((link) => link.includes('soundcloud.com'));
-  const spotifyLink = cast.alternativeEmbeds.find((link) => link.includes('spotify.com'));
 
   if (youtubeLink) {
     return await getYoutubeTrackMetadata(youtubeLink, cast);
-  } else if(soundcloudLink) {
-    return await getSoundcloudTrackMetadata(soundcloudLink, cast);
   }
 
-  return await getSpotifyTrackMetadata(spotifyLink!, cast);
-
+  if(soundcloudLink) {
+    return await getSoundcloudTrackMetadata(soundcloudLink, cast);
+  }
 
   const oEmbedUrl = `https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`;
   const response = await fetch(oEmbedUrl);


### PR DESCRIPTION
## Changelog 

- getSpotifyTrackMetadata prioritized YouTube
- if there is no YouTube link then added soundcloud
- if there is no soundcloud link added spotify.